### PR TITLE
remove "-cleaned" from filename

### DIFF
--- a/kfkd.py
+++ b/kfkd.py
@@ -39,7 +39,7 @@ np.random.seed(42)
 Conv2DLayer = layers.cuda_convnet.Conv2DCCLayer
 MaxPool2DLayer = layers.cuda_convnet.MaxPool2DCCLayer
 
-FTRAIN = '~/data/kaggle-facial-keypoint-detection/training-cleaned.csv'
+FTRAIN = '~/data/kaggle-facial-keypoint-detection/training.csv'
 FTEST = '~/data/kaggle-facial-keypoint-detection/test.csv'
 FLOOKUP = '~/data/kaggle-facial-keypoint-detection/IdLookupTable.csv'
 


### PR DESCRIPTION
as far as i can tell, this script works correctly without any changes after downloading the file from kaggle. so i thought it might be clearer to use the original filename.
