### PR TITLE
Changes for Python 3.4.4.3

### DIFF
--- a/kfkd.py
+++ b/kfkd.py
@@ -17,7 +17,7 @@ And finally make predictions to submit to Kaggle:
   python kfkd.py predict net-specialists.pickle
 """
 
-import cPickle as pickle
+import six.moves.cPickle as pickle
 from datetime import datetime
 import os
 import sys
@@ -367,7 +367,7 @@ def rebin( a, newshape ):
 
 
 def plot_learning_curves(fname_specialists='net-specialists.pickle'):
-    with open(fname_specialists, 'r') as f:
+    with open(fname_specialists, 'rb') as f:
         models = pickle.load(f)
 
     fig = pyplot.figure(figsize=(10, 6))


### PR DESCRIPTION
- Pickle latest version is all binary, hence using rb instead of r
- Pickle import related change

This is tested on Windows10, with Python 3.4.4.3

If this is not used, decoding error happens, log below:

\WinPython-64bit-3.4.4.3\scripts..\python-3.4.4.amd64\lib\encodings\cp1252.py", line 23, in decode
   return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 1216: character maps to <undefined>
